### PR TITLE
This closes # 18 . 'connected' is now firing when connected

### DIFF
--- a/lib/Phidget.js
+++ b/lib/Phidget.js
@@ -351,6 +351,7 @@ function Phidget(){
     };
 
     function connected(){
+        phidget.emit('connected');
         this.setEncoding('utf8');
         //phidget.client.setKeepAlive('enable', 10000);
 


### PR DESCRIPTION
Added 

```
 phidget.emit('connected');
```

to the connected function
