### PR TITLE
Fix connection to non-localhost phidgetwebservices.

### DIFF
--- a/lib/Phidget.js
+++ b/lib/Phidget.js
@@ -95,7 +95,7 @@ function Phidget(){
 
     function setParams(params){
         for(var key in params){
-            if(!phidgetParams[key])
+            if(!!params[key])
                 phidgetParams[key]=params[key];
         }
         for(var key in this.defaults){


### PR DESCRIPTION
Allow settings to be passed through to new.createConnection. Currently, nothing is passed through.

I found this when i tried to connect to a remote server, on `10.0.1.8` and it was still connecting to the one on `localhost` as that's the default.
